### PR TITLE
Add developer option reboot to global actions menu

### DIFF
--- a/build/prepare
+++ b/build/prepare
@@ -20,5 +20,11 @@ do
   done
 done
 
+# Add developer option to include reboot in global actions menu
+cd $ANDROID_BUILD_TOP/frameworks/base
+git fetch https://android.googlesource.com/platform/frameworks/base refs/changes/72/184272/4 && git cherry-pick FETCH_HEAD
+cd $ANDROID_BUILD_TOP/packages/apps/Settings
+git fetch https://android.googlesource.com/platform/packages/apps/Settings refs/changes/69/183769/3 && git cherry-pick FETCH_HEAD
+
 rm -rf ${TOP}/hardware/qcom/gps/msm8084
 rm -rf ${TOP}/hardware/qcom/gps/msm8974


### PR DESCRIPTION
This feature can be quite useful due to the regular ROM updates. However Google has rejected its inclusion in AOSP in the past and therefore I would understand if you decided to not pulling it into your own source code.

The original request from Sony Corp is documented at:
https://android-review.googlesource.com/#/c/184272/4
and
https://android-review.googlesource.com/#/c/183769/3

PS: great job with this project! I was trying to bring Marshmallow to my Nexus 4 on my own but I am not a programmer and was unable to. I feel I have learned a lot about AOSP ROM building from looking at and making small changes to your source code. Thank you!
